### PR TITLE
[#9] Support Grouping without grouping keys

### DIFF
--- a/src/main/java/edu/dbsleipzig/stream/grouping/impl/algorithm/GraphStreamGrouping.java
+++ b/src/main/java/edu/dbsleipzig/stream/grouping/impl/algorithm/GraphStreamGrouping.java
@@ -19,7 +19,6 @@ import edu.dbsleipzig.stream.grouping.impl.functions.aggregation.CustomizedAggre
 import edu.dbsleipzig.stream.grouping.impl.functions.utils.WindowConfig;
 import edu.dbsleipzig.stream.grouping.model.graph.GraphStreamToGraphStreamOperator;
 import edu.dbsleipzig.stream.grouping.model.graph.StreamGraph;
-import edu.dbsleipzig.stream.grouping.model.graph.StreamGraphConfig;
 import edu.dbsleipzig.stream.grouping.model.graph.StreamGraphLayout;
 import edu.dbsleipzig.stream.grouping.model.table.TableSet;
 import org.apache.flink.table.api.Table;
@@ -132,7 +131,6 @@ public class GraphStreamGrouping extends TableGroupingBase implements GraphStrea
     public Table prepareVertices() {
         return this.getTableEnv().sqlQuery(
           "SELECT " +
-            "'d' as dummy, " +
             FIELD_VERTEX_ID + " as " + FIELD_VERTEX_ID + ", " +
             FIELD_VERTEX_LABEL + " as " + FIELD_VERTEX_LABEL + ", " +
             FIELD_VERTEX_PROPERTIES + " as " + FIELD_VERTEX_PROPERTIES + ", " +

--- a/src/main/java/edu/dbsleipzig/stream/grouping/impl/algorithm/GraphStreamGrouping.java
+++ b/src/main/java/edu/dbsleipzig/stream/grouping/impl/algorithm/GraphStreamGrouping.java
@@ -132,6 +132,7 @@ public class GraphStreamGrouping extends TableGroupingBase implements GraphStrea
     public Table prepareVertices() {
         return this.getTableEnv().sqlQuery(
           "SELECT " +
+            "'d' as dummy, " +
             FIELD_VERTEX_ID + " as " + FIELD_VERTEX_ID + ", " +
             FIELD_VERTEX_LABEL + " as " + FIELD_VERTEX_LABEL + ", " +
             FIELD_VERTEX_PROPERTIES + " as " + FIELD_VERTEX_PROPERTIES + ", " +

--- a/src/main/java/edu/dbsleipzig/stream/grouping/impl/algorithm/TableGroupingBase.java
+++ b/src/main/java/edu/dbsleipzig/stream/grouping/impl/algorithm/TableGroupingBase.java
@@ -552,7 +552,7 @@ public abstract class TableGroupingBase {
         PlannerExpressionSeqBuilder selectFromExpandedVertices =
           new PlannerExpressionSeqBuilder(getTableEnv());
         selectFromExpandedVertices.field(FIELD_VERTEX_ID);
-        selectFromExpandedVertices.field("preparedVerticesTime").as(FIELD_EVENT_TIME);
+        selectFromExpandedVertices.field(PREPARED_VERTICES_EVENT_TIME).as(FIELD_EVENT_TIME);
         selectFromExpandedVertices.field(FIELD_SUPER_VERTEX_ID);
         if (useVertexLabels) {
             selectFromExpandedVertices.field(FIELD_SUPER_VERTEX_LABEL);
@@ -575,7 +575,7 @@ public abstract class TableGroupingBase {
             selectPreparedVerticesGroupAttributes.field(FIELD_VERTEX_LABEL);
         }
 
-        selectPreparedVerticesGroupAttributes.field(FIELD_VERTEX_EVENT_TIME).as("preparedVerticesTime");
+        selectPreparedVerticesGroupAttributes.field(FIELD_VERTEX_EVENT_TIME).as(PREPARED_VERTICES_EVENT_TIME);
         selectPreparedVerticesGroupAttributes.field(FIELD_VERTEX_ID);
         return selectPreparedVerticesGroupAttributes.build();
     }
@@ -621,8 +621,8 @@ public abstract class TableGroupingBase {
             $(FIELD_VERTEX_LABEL).isNull().and($(FIELD_SUPER_VERTEX_LABEL).isNull()));
         }
 
-        ApiExpression temporalExpression = $("preparedVerticesTime").isLessOrEqual($(FIELD_SUPER_VERTEX_ROWTIME))
-                .and($("preparedVerticesTime").isGreater($(FIELD_SUPER_VERTEX_ROWTIME).minus(windowConfig.getWindowExpression())));
+        ApiExpression temporalExpression = $(PREPARED_VERTICES_EVENT_TIME).isLessOrEqual($(FIELD_SUPER_VERTEX_ROWTIME))
+                .and($(PREPARED_VERTICES_EVENT_TIME).isGreater($(FIELD_SUPER_VERTEX_ROWTIME).minus(windowConfig.getWindowExpression())));
 
         ApiExpression[] apiExpressionArray = Arrays.stream(attributeJoinConditions.build()).toArray(ApiExpression[]::new);
 

--- a/src/main/java/edu/dbsleipzig/stream/grouping/impl/functions/utils/PlannerExpressionBuilder.java
+++ b/src/main/java/edu/dbsleipzig/stream/grouping/impl/functions/utils/PlannerExpressionBuilder.java
@@ -270,6 +270,25 @@ public class PlannerExpressionBuilder {
     }
 
     /**
+     * Appends a call of boolean "OR(expression)" operator with given expression to current
+     * expression
+     * Builds a boolean expression!
+     *
+     * @param expression expression
+     * @return a reference to this object
+     */
+    public PlannerExpressionBuilder or(ApiExpression expression) {
+        if (null == currentExpression) {
+            currentExpression = expression;
+        }
+        else {
+            currentExpression = currentExpression.or(expression);
+        }
+
+        return this;
+    }
+
+    /**
      * Builds a row expression. Used only as scalar function argument at {@link ToProperties}.
      *
      * @param expressions the expression for the row.

--- a/src/main/java/edu/dbsleipzig/stream/grouping/model/table/TableSet.java
+++ b/src/main/java/edu/dbsleipzig/stream/grouping/model/table/TableSet.java
@@ -104,7 +104,7 @@ public class TableSet extends HashMap<String, Table> {
     /**
      * Field name if not grouping on label
      */
-    public static final String FIELD_NO_LABEL = "no_label";
+    public static final String FIELD_NO_LABEL = "";
     /**
      * Table key of vertices table
      */

--- a/src/main/java/edu/dbsleipzig/stream/grouping/model/table/TableSet.java
+++ b/src/main/java/edu/dbsleipzig/stream/grouping/model/table/TableSet.java
@@ -102,6 +102,10 @@ public class TableSet extends HashMap<String, Table> {
      */
     public static final String PREPARED_VERTICES_EVENT_TIME = "prepared_vertices_event_time";
     /**
+     * Field name if not grouping on label
+     */
+    public static final String FIELD_NO_LABEL = "no_label";
+    /**
      * Table key of vertices table
      */
     public static final String TABLE_VERTICES = "vertices";

--- a/src/main/java/edu/dbsleipzig/stream/grouping/model/table/TableSet.java
+++ b/src/main/java/edu/dbsleipzig/stream/grouping/model/table/TableSet.java
@@ -98,6 +98,10 @@ public class TableSet extends HashMap<String, Table> {
      */
     public static final String FIELD_VERTEX_EVENT_TIME = "vertex_event_time";
     /**
+     * Field name of prepared vertex timestamp
+     */
+    public static final String PREPARED_VERTICES_EVENT_TIME = "prepared_vertices_event_time";
+    /**
      * Table key of vertices table
      */
     public static final String TABLE_VERTICES = "vertices";


### PR DESCRIPTION
Grouping without keys results in a single super-edge/vertex. Every aggregation is over all edges/vertices. Fix errors when not grouping on label on the fly.